### PR TITLE
FBT: Compile-time defines for Kiisu

### DIFF
--- a/fbt_options.py
+++ b/fbt_options.py
@@ -3,7 +3,7 @@ import posixpath
 
 # For more details on these options, run 'fbt -h'
 
-FIRMWARE_ORIGIN = "Official"
+FIRMWARE_ORIGIN = "Kiisu"
 
 # Default hardware target
 TARGET_HW = 7

--- a/firmware.scons
+++ b/firmware.scons
@@ -114,6 +114,7 @@ lib_targets = env.BuildModules(
 env.Append(
     CPPDEFINES=[
         env.subst("FW_ORIGIN_${FIRMWARE_ORIGIN}"),
+        "KIISU",
     ]
 )
 


### PR DESCRIPTION
# What's new

- Adds a `KIISU` define so app makers can check for the platform and potentially expand their apps compared to Flipper Zero's capabilities with `#ifdef KIISU` and the like
- Changed firmware origin: this creates a `FW_ORIGIN_Kiisu` instead of `FW_ORIGIN_Official`, this is standard practice with all Flipper firmware forks
- They are 2 separate defines because one describes the platform while the other describes the firmware, relying on just `FW_ORIGIN_Kiisu` would prevent support on hypothetical custom firmwares for Kiisu

# Side notes

- Kiisu is looking really great, amazing work! I'll probably order one in the next few days
- I know it is very early still with this fork, but I wanted to suggest possibly distributing an SDK (created with `./fbt updater_package` as usual), and potentially an update server similar to https://update.flipperzero.one/firmware/directory.json as that would allow app developers to easily develop for Kiisu with `ufbt update --index-url <url>`
- I develop Momentum, a custom Flipper firmware; I merged the changes from this fork into [a branch](https://github.com/Next-Flip/Momentum-Firmware/tree/kiisu-mntm) that I'll be keeping updated for now, not sure yet if I will add Kiisu builds to Momentum releases yet; for now there are binaries automatically added to the PR I'm keeping open for the branch. I hope this is OK with you, if not please let me know :D

# Verification 

- Not much to verify honestly lol

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
