### PR TITLE
NFC: Fix BusFault in Write to Initial Card

### DIFF
--- a/lib/nfc/protocols/mf_classic/mf_classic_poller.c
+++ b/lib/nfc/protocols/mf_classic/mf_classic_poller.c
@@ -39,6 +39,9 @@ MfClassicPoller* mf_classic_poller_alloc(Iso14443_3aPoller* iso14443_3a_poller) 
     instance->rx_encrypted_buffer = bit_buffer_alloc(MF_CLASSIC_MAX_BUFF_SIZE);
     instance->current_type_check = MfClassicType4k;
     instance->card_state = MfClassicCardStateLost;
+    // Default to a non-dict-attack mode so mf_classic_poller_free() never frees
+    // union members that were never used if the poller is freed before it starts.
+    instance->mode = MfClassicPollerModeRead;
 
     instance->mfc_event.data = &instance->mfc_event_data;
 
@@ -65,24 +68,31 @@ void mf_classic_poller_free(MfClassicPoller* instance) {
     bit_buffer_free(instance->tx_encrypted_buffer);
     bit_buffer_free(instance->rx_encrypted_buffer);
 
-    // Clean up resources in MfClassicPollerDictAttackContext
-    MfClassicPollerDictAttackContext* dict_attack_ctx = &instance->mode_ctx.dict_attack_ctx;
+    // Clean up resources in MfClassicPollerDictAttackContext, but only when the
+    // poller actually ran a dict attack. mode_ctx is a union: in Read/Write modes
+    // the bytes that overlap nested_nonce.nonces (e.g. write_ctx.tag_block) hold
+    // unrelated data, so freeing them unconditionally dereferences a garbage
+    // pointer and triggers a BusFault (flipperdevices/flipperzero-firmware#4108).
+    if(instance->mode == MfClassicPollerModeDictAttackStandard ||
+       instance->mode == MfClassicPollerModeDictAttackEnhanced) {
+        MfClassicPollerDictAttackContext* dict_attack_ctx = &instance->mode_ctx.dict_attack_ctx;
 
-    // Free the dictionaries
-    if(dict_attack_ctx->mf_classic_system_dict) {
-        keys_dict_free(dict_attack_ctx->mf_classic_system_dict);
-        dict_attack_ctx->mf_classic_system_dict = NULL;
-    }
-    if(dict_attack_ctx->mf_classic_user_dict) {
-        keys_dict_free(dict_attack_ctx->mf_classic_user_dict);
-        dict_attack_ctx->mf_classic_user_dict = NULL;
-    }
+        // Free the dictionaries
+        if(dict_attack_ctx->mf_classic_system_dict) {
+            keys_dict_free(dict_attack_ctx->mf_classic_system_dict);
+            dict_attack_ctx->mf_classic_system_dict = NULL;
+        }
+        if(dict_attack_ctx->mf_classic_user_dict) {
+            keys_dict_free(dict_attack_ctx->mf_classic_user_dict);
+            dict_attack_ctx->mf_classic_user_dict = NULL;
+        }
 
-    // Free the nested nonce array if it exists
-    if(dict_attack_ctx->nested_nonce.nonces) {
-        free(dict_attack_ctx->nested_nonce.nonces);
-        dict_attack_ctx->nested_nonce.nonces = NULL;
-        dict_attack_ctx->nested_nonce.count = 0;
+        // Free the nested nonce array if it exists
+        if(dict_attack_ctx->nested_nonce.nonces) {
+            free(dict_attack_ctx->nested_nonce.nonces);
+            dict_attack_ctx->nested_nonce.nonces = NULL;
+            dict_attack_ctx->nested_nonce.count = 0;
+        }
     }
 
     free(instance);
@@ -162,6 +172,9 @@ NfcCommand mf_classic_poller_handler_start(MfClassicPoller* instance) {
 
     instance->mfc_event.type = MfClassicPollerEventTypeRequestMode;
     command = instance->callback(instance->general_event, instance->context);
+    // Remember the selected mode so mf_classic_poller_free() knows which union
+    // member of mode_ctx is actually live and safe to clean up.
+    instance->mode = instance->mfc_event_data.poller_mode.mode;
 
     if(instance->mfc_event_data.poller_mode.mode == MfClassicPollerModeDictAttackStandard) {
         mf_classic_copy(instance->data, instance->mfc_event_data.poller_mode.data);

--- a/lib/nfc/protocols/mf_classic/mf_classic_poller_i.h
+++ b/lib/nfc/protocols/mf_classic/mf_classic_poller_i.h
@@ -181,6 +181,7 @@ struct MfClassicPoller {
 
     MfClassicType current_type_check;
     uint8_t sectors_total;
+    MfClassicPollerMode mode;
     MfClassicPollerModeContext mode_ctx;
 
     Crypto1* crypto;


### PR DESCRIPTION
## What's new

Fixes a BusFault crash when using **NFC → Saved → Write to initial card** on a Mifare Classic card (writing a saved `.nfc` back to its original card).

### Root cause

`mode_ctx` in `MfClassicPoller` is a `union`. In Write/Read modes the live member is `write_ctx`, whose `tag_block` overlaps in memory with `dict_attack_ctx.nested_nonce.nonces` (a pointer). `mf_classic_poller_free()` freed `nested_nonce.nonces` **unconditionally**, so in Write mode it called `free()` on leftover tag bytes reinterpreted as a pointer → **BusFault**. This also explains why the crash was timing-dependent (the overlapping bytes vary).

### Fix

Track the active poller mode in `instance->mode` (set in `mf_classic_poller_handler_start`, defaulted to a non-dict-attack mode in `_alloc`), and only clean up the dict-attack context (dictionaries + nested nonce array) when the poller actually ran a dict attack.

Same root cause and fix as the upstream report flipperdevices/flipperzero-firmware#4108 and its fix PR https://github.com/flipperdevices/flipperzero-firmware/pull/4362. Kiisu's `mf_classic` code is identical to upstream, so the bug is present here as well.

## Verification

- Firmware builds cleanly with the change (`./fbt`).
- The identical patch was built, flashed and tested on the official firmware and on Momentum: *Write to initial card* now completes with **no crash** (previously an instant BusFault), tested in normal conditions (no serial `log trace` session, which used to mask the crash).
- Also built and flashed onto **real Kiisu hardware**: the patched firmware boots and runs there too, with the same `mf_classic` code path as the firmwares above.
